### PR TITLE
WIP update to nrfxlib v1.4.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,12 @@ jobs:
     strategy:
       matrix:
         target:
-          - thumbv8m.main-none-eabihf
           - thumbv8m.main-none-eabi
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           target: ${{ matrix.target }}
           override: true
       - uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/42-technology-ltd/nrfxlib"
 description = "Rust driver for the LTE stack on the Nordic nRF9160"
+resolver = "2"
 
 [dependencies]
 nrf9160-pac = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,4 @@ nrf9160-pac = "0.2.1"
 cortex-m = "0.6"
 heapless = "0.5"
 log = "0.4"
-
-# Note: when v1.4.2 is upstreamed we can merge this again.
-# nrfxlib-sys = "1.2.0"
-nrfxlib-sys = { git = "https://github.com/Wassasin/nrfxlib-sys", branch = "nrfxlib-v1.4.2" }
+nrfxlib-sys = "1.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,11 @@ repository = "https://github.com/42-technology-ltd/nrfxlib"
 description = "Rust driver for the LTE stack on the Nordic nRF9160"
 
 [dependencies]
-nrfxlib-sys = "1.2.0"
 nrf9160-pac = "0.2.1"
 cortex-m = "0.6"
 heapless = "0.5"
 log = "0.4"
+
+# Note: when v1.4.2 is upstreamed we can merge this again.
+# nrfxlib-sys = "1.2.0"
+nrfxlib-sys = { git = "https://github.com/Wassasin/nrfxlib-sys", branch = "nrfxlib-v1.4.2" }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See [nrf9160-demo](https://github.com/42-technology-ltd/nrf9160-demo) for a demo
 
 ### Unreleased Changes ([Source](https://github.com/42-technology-ltd/nrfxlib/tree/master) | [Changes](https://github.com/42-technology-ltd/nrfxlib/compare/v0.5.0...master))
 
-* None
+* Updated to nrfxlib version 1.4.2. This requires Rust v1.51 as we use the new resolver to allow bindgen as a build-dep.
 
 ### v0.5.0 ([Source](https://github.com/42-technology-ltd/nrfxlib/tree/v0.5.0) | [Changes](https://github.com/42-technology-ltd/nrfxlib/compare/v0.4.0...v0.5.0))
 

--- a/src/at.rs
+++ b/src/at.rs
@@ -53,7 +53,7 @@ pub struct AtSocket(Socket);
 impl AtSocket {
 	/// Create a new AT socket.
 	pub fn new() -> Result<AtSocket, Error> {
-		let skt = Socket::new(SocketDomain::Lte, SocketType::None, SocketProtocol::At)?;
+		let skt = Socket::new(SocketDomain::Lte, SocketType::Datagram, SocketProtocol::At)?;
 		Ok(AtSocket(skt))
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,10 +177,10 @@ impl core::fmt::Display for NrfSockAddrIn {
 		write!(
 			f,
 			"{}.{}.{}.{}:{}",
-			octets[0],
-			octets[1],
-			octets[2],
 			octets[3],
+			octets[2],
+			octets[1],
+			octets[0],
 			u16::from_be(self.sin_port)
 		)
 	}


### PR DESCRIPTION
This MR updates nrfxlib to v1.4.2, which is the latest stable version. v1.5.0 is almost released, but will prove to be a bigger albeit more promising update. I required this update due to the better socket connection establishment implementation in the newer bsdlib.

Note that temporarily I include my own fork of nrfxlib-sys, which I updated without being aware of the previous efforts by @jonathanpallant. Once https://github.com/42-technology-ltd/nrfxlib-sys/pull/2 gets merged and released I'll change this merge request to point to the canonical one again. One minor issue is that this new nrfxlib-sys requires nightly, until `-Zfeatures=host_dep` ends up in stable. However that should not be a blocking issue for this merge request.

The changes required to update this library (afaik) are as follows:
- socket creation is more strict, requiring the Datagram type for At sockets. (since bsdlib 0.6.2) Therefor socket type `None` is no longer an appropriate value.
- bsdlib init requires parameters detailing the memory block set aside for the library. Because nrfxlib does not implement having no traces, `trace_on` should always be true. Perhaps we should not give the option to the end user.
- the fields of `nrf_pollfd` got renamed upstream.
- linking to nrfxlib now requires `strncpy`, which I added and has been merged at https://github.com/rust-embedded-community/tinyrlibc/pull/2.

I also fixed a minor issue with debug logging `NrfSockAddrIn` objects. We could move that out of this MR if so desired.