### PR TITLE
Bump dependencies: nrf9160-pac = "0.12", cortex-m = "0.7"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ description = "Rust driver for the LTE stack on the Nordic nRF9160"
 resolver = "2"
 
 [dependencies]
-nrf9160-pac = "0.2.1"
-cortex-m = "0.6"
+nrf9160-pac = "0.12"
+cortex-m = "0.7"
 heapless = "0.7"
-linked_list_allocator = { version="0.9.0", default-features=false, features=["use_spin"] }
+linked_list_allocator = { version = "0.10", default-features = false, features = [
+    "use_spin",
+] }
 log = "0.4"
 nrfxlib-sys = "=1.5.1"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -226,7 +226,7 @@ pub extern "C" fn nrfx_ipc_init(
 	let irq_num = usize::from(irq.number());
 	unsafe {
 		cortex_m::peripheral::NVIC::unmask(irq);
-		(*cortex_m::peripheral::NVIC::ptr()).ipr[irq_num].write(irq_priority);
+		(*cortex_m::peripheral::NVIC::PTR).ipr[irq_num].write(irq_priority);
 	}
 	IPC_CONTEXT.store(p_context, core::sync::atomic::Ordering::SeqCst);
 	IPC_HANDLER.store(handler as usize, core::sync::atomic::Ordering::SeqCst);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,10 +160,11 @@ pub fn init() -> Result<(), Error> {
 	unsafe {
 		/// Allocate some space in global data to use as a heap.
 		static mut HEAP_MEMORY: [u32; 1024] = [0u32; 1024];
-		let heap_start = HEAP_MEMORY.as_ptr() as usize;
+		let heap_start = HEAP_MEMORY.as_mut_ptr() as *mut _;
 		let heap_size = HEAP_MEMORY.len() * core::mem::size_of::<u32>();
 		cortex_m::interrupt::free(|cs| {
-			*LIBRARY_ALLOCATOR.borrow(cs).borrow_mut() = Some(Heap::new(heap_start, heap_size))
+			*LIBRARY_ALLOCATOR.borrow(cs).borrow_mut() =
+				Some(Heap::new(heap_start, heap_size))
 		});
 	}
 
@@ -198,7 +199,7 @@ pub fn init() -> Result<(), Error> {
 		// Use the same TX memory region as above
 		cortex_m::interrupt::free(|cs| {
 			*TX_ALLOCATOR.borrow(cs).borrow_mut() = Some(Heap::new(
-				params.shmem.tx.base as usize,
+				params.shmem.tx.base as *mut _,
 				params.shmem.tx.size as usize,
 			))
 		});


### PR DESCRIPTION
Fixes `rust-lld: error: duplicate symbol: DEVICE_PERIPHERALS` when building an app that relies on recent (i.e. v0.12) nRF9160 PAC