### PR TITLE
Fix memory ownership issue in the init function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrfxlib"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Jonathan Pallant (42 Technology) <jonathan.pallant@42technology.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -18,3 +18,4 @@ linked_list_allocator = { version = "0.10", default-features = false, features =
 ] }
 log = "0.4"
 nrfxlib-sys = "=1.5.1"
+grounded = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -73,9 +73,16 @@ See [nrf9160-demo](https://github.com/42-technology-ltd/nrf9160-demo) for a demo
 
 ## Changelog
 
-### Unreleased Changes ([Source](https://github.com/42-technology-ltd/nrfxlib/tree/develop) | [Changes](https://github.com/42-technology-ltd/nrfxlib/compare/v0.6.0...develop))
+### Unreleased Changes ([Source](https://github.com/42-technology-ltd/nrfxlib/tree/develop) | [Changes](https://github.com/42-technology-ltd/nrfxlib/compare/v0.6.1...develop))
 
 * None
+
+### v0.6.1 ([Source](https://github.com/42-technology-ltd/nrfxlib/tree/v0.6.1) | [Changes](https://github.com/42-technology-ltd/nrfxlib/compare/v0.6.0...v0.6.1))
+
+* Fixed a memory ownership issue in `nrf_modem_init`. The `nrf_modem_init_params` pointer given to the init must
+  have a static lifetime. This has been a stack variable since forever.  
+  Originally this seems to have not been required, but this changed +-4 years ago
+  without documentation update from Nordic.
 
 ### v0.6.0 ([Source](https://github.com/42-technology-ltd/nrfxlib/tree/v0.6.0) | [Changes](https://github.com/42-technology-ltd/nrfxlib/compare/v0.5.0...v0.6.0))
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,13 +163,12 @@ pub fn init() -> Result<(), Error> {
 		let heap_start = HEAP_MEMORY.as_mut_ptr() as *mut _;
 		let heap_size = HEAP_MEMORY.len() * core::mem::size_of::<u32>();
 		cortex_m::interrupt::free(|cs| {
-			*LIBRARY_ALLOCATOR.borrow(cs).borrow_mut() =
-				Some(Heap::new(heap_start, heap_size))
+			*LIBRARY_ALLOCATOR.borrow(cs).borrow_mut() = Some(Heap::new(heap_start, heap_size))
 		});
 	}
 
 	// Tell nrf_modem what memory it can use.
-	static PARAMS: grounded::uninit::GroundedCell<nrfxlib_sys::nrf_modem_init_params> =
+	static PARAMS: grounded::uninit::GroundedCell<nrfxlib_sys::nrf_modem_init_params_t> =
 		grounded::uninit::GroundedCell::uninit();
 
 	let params = sys::nrf_modem_init_params_t {


### PR DESCRIPTION
So I've been debugging this problem for many days now. Over at my `nrf-modem` I made this same patch.
It turns out that the params given to the init function need to live forever. Seems like the params aren't copied over, but are still referenced later.

No idea why nobody caught this earlier.
But this fixes it.

If anybody reviews and merges I can publish the new release.

Note though that I have some difficulties to compile this crate now. I think the bindgen version for nrfxlib-sys is quite old now.